### PR TITLE
Pass order

### DIFF
--- a/src/basis_structure.jl
+++ b/src/basis_structure.jl
@@ -268,7 +268,7 @@ function BasisStructure(basis::Basis, ::Expanded,
                         x::Array=nodes(basis)[1], order=0)  # funbasex
     # create direct form, then convert to expanded
     bsd = BasisStructure(basis, Direct(), x, order)
-    convert(Expanded, bsd, order)
+    convert(Expanded, bsd, bds.order)
 end
 
 function BasisStructure{N,BF,T}(basis::Basis{N,BF}, ::Tensor,

--- a/src/basis_structure.jl
+++ b/src/basis_structure.jl
@@ -268,7 +268,7 @@ function BasisStructure(basis::Basis, ::Expanded,
                         x::Array=nodes(basis)[1], order=0)  # funbasex
     # create direct form, then convert to expanded
     bsd = BasisStructure(basis, Direct(), x, order)
-    convert(Expanded, bsd, bds.order)
+    convert(Expanded, bsd, bsd.order)
 end
 
 function BasisStructure{N,BF,T}(basis::Basis{N,BF}, ::Tensor,

--- a/src/basis_structure.jl
+++ b/src/basis_structure.jl
@@ -268,7 +268,7 @@ function BasisStructure(basis::Basis, ::Expanded,
                         x::Array=nodes(basis)[1], order=0)  # funbasex
     # create direct form, then convert to expanded
     bsd = BasisStructure(basis, Direct(), x, order)
-    convert(Expanded, bsd)
+    convert(Expanded, bsd, order)
 end
 
 function BasisStructure{N,BF,T}(basis::Basis{N,BF}, ::Tensor,


### PR DESCRIPTION
Otherwise the following returns an error:

``` julia
 basisμ = Basis(Cheb, 20, 0.0, 1.0)
 basisσ = Basis(Cheb, 20, 0.0, 1.0)
basis = Basis(basisμ, basisσ)
S, (μs, σs) = nodes(basis)
bs = BasisStructure(basis, Expanded(), S, [0 2])
```
