### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/test/cheb.jl
+++ b/test/cheb.jl
@@ -2,7 +2,7 @@
 module TestCheb
 
 # include instead of `using` so it updates when I reload the module
-include(Pkg.dir("CompEcon", "src", "CompEcon.jl"))
+include(joinpath(dirname(@__FILE__), "..", "src", "CompEcon.jl"))
 using Base.Test
 using FactCheck
 

--- a/test/interp.jl
+++ b/test/interp.jl
@@ -2,7 +2,7 @@
 module TestInterp
 
 # include instead of `using` so it updates when I reload the module
-include(Pkg.dir("CompEcon", "src", "CompEcon.jl"))
+include(joinpath(dirname(@__FILE__), "..", "src", "CompEcon.jl"))
 using Base.Test
 using FactCheck
 


### PR DESCRIPTION
This allows installing the package elsewhere.

(minor thing, no need to retag for this)
