### PR TITLE
reorder BasisMatrix call to match constructor

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -55,7 +55,7 @@ end
 # add method to funbasex that creates a BasisStructure
 function funbasex(basis::Basis, x=nodes(basis)[1], order=0,
                   bformat::BasisMatrices.ABSR=Direct())
-    BasisMatrix(basis, x, order, bformat)
+    BasisMatrix(Void, basis, bformat, x, order)
 end
 
 funbase(basis::Basis, x=nodes(basis)[1], order=fill(0, 1, ndims(basis))) =


### PR DESCRIPTION
I'm not sure when BasisMatrix() changed, but this seems to work.

I briefly looked at Travis-CI to see if I could fix the build as well, but I'm unfamiliar so didn't know why it wasn't seeing later versions of BasisMatrices.

Let me know if you want me to add a test somewhere or something.