### PR TITLE
Change minimum requirement to Julia 0.7 and above

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.7 2
 QuantEcon
 BasisMatrices 0.3
 Reexport


### PR DESCRIPTION
Checks fail for merging into METADATA, probably have to change also the minimal requirements to 0.7 up to 2.0. I copied this line from QuantEcon.jl. I am not sure if another formulation is preferable.