### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The corresponding Julia code is
 ```julia
 using CompEcon
 # function to approximate
-f(x) = exp(-x)
+f(x) = exp.(-x)
 
 # Set the endpoints of approximation interval:
 a =  -1                            # left endpoint


### PR DESCRIPTION
The version with `f(x) = exp(x)` throws the following error:

```
ERROR: MethodError: no method matching exp(::Vector{Float64})
Closest candidates are:
  exp(::Union{Float16, Float32, Float64}) at C:\Users\kantorov\.julia\juliaup\julia-1.7.2+0~x64\share\julia\base\special\exp.jl:296
  exp(::StridedMatrix{var"#s859"} where var"#s859"<:Union{Float32, Float64, ComplexF32, ComplexF64}) at C:\Users\kantorov\.julia\juliaup\julia-1.7.2+0~x64\share\julia\stdlib\v1.7\LinearAlgebra\src\dense.jl:560
  exp(::StridedMatrix{var"#s859"} where var"#s859"<:Union{Integer, Complex{<:Integer}}) at C:\Users\kantorov\.julia\juliaup\julia-1.7.2+0~x64\share\julia\stdlib\v1.7\LinearAlgebra\src\dense.jl:561
  ...
Stacktrace:
 [1] f(x::Vector{Float64})
   @ Main l:\AssetTokenization\Model Sketch\main_new.jl:8
 [2] funfitf(::Basis{1, Tuple{ChebParams{Float64}}}, ::Function)
   @ BasisMatrices C:\Users\kantorov\.julia\packages\BasisMatrices\PZ1uM\src\interp.jl:68
 [3] funfitf(::Dict{Symbol, Any}, ::Function)
   @ CompEcon C:\Users\kantorov\.julia\packages\CompEcon\9POAs\src\core.jl:134
 [4] top-level scope
   @ l:\AssetTokenization\Model Sketch\main_new.jl:21
```

Which is fixed by replacing `f(x) = exp.(-x)`